### PR TITLE
Add search functionality to CMS server with authorization option.

### DIFF
--- a/client/src/main/java/com/sastix/cms/client/impl/CmsClient.java
+++ b/client/src/main/java/com/sastix/cms/client/impl/CmsClient.java
@@ -390,6 +390,11 @@ public class CmsClient implements ContentClient, LockClient, CacheClient, BeanFa
         return retLockDTO;
     }
 
+    @Override
+    public List<ResourceDTO> queryResourceByFields(ResourceFieldsQueryDTO resourceQueryDTO) throws ResourceAccessError, ResourceNotFound, ContentValidationException {
+        return null;
+    }
+
     private void nullValidationChecker(Object obj, Class aClass) {
         if (obj == null) {
             throw new CacheValidationException(aClass + " object cannot be null!");

--- a/common/api/src/main/java/com/sastix/cms/common/api/ContentApi.java
+++ b/common/api/src/main/java/com/sastix/cms/common/api/ContentApi.java
@@ -23,6 +23,7 @@ import com.sastix.cms.common.content.exceptions.ResourceNotFound;
 import com.sastix.cms.common.content.exceptions.ResourceNotOwned;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface ContentApi {
 
@@ -38,11 +39,12 @@ public interface ContentApi {
 
     ResourceDTO queryResource(ResourceQueryDTO resourceQueryDTO) throws ResourceAccessError, ResourceNotFound, ContentValidationException;
 
+    List<ResourceDTO> queryResourceByFields(ResourceFieldsQueryDTO resourceQueryDTO) throws ResourceAccessError, ResourceNotFound, ContentValidationException;
+
     ResourceDTO deleteResource(LockedResourceDTO lockedResourceDTO) throws ResourceNotOwned, ResourceAccessError, ContentValidationException;
 
     String getParentResource(String uuid);
 
     byte[] getData(DataDTO dataDTO) throws ResourceAccessError, ContentValidationException, IOException;
-
 
 }

--- a/common/dataobjects/src/main/java/com/sastix/cms/common/Constants.java
+++ b/common/dataobjects/src/main/java/com/sastix/cms/common/Constants.java
@@ -31,6 +31,7 @@ public interface Constants {
     static String CREATE_RESOURCE = "createResource";
     static String UPDATE_RESOURCE = "updateResource";
     static String QUERY_RESOURCE = "queryResource";
+    static String QUERY_RESOURCE_BY_FIELDS = "queryResourceByFields";
     static String DELETE_RESOURCE = "deleteResource";
     static String GET_DATA = "getData";
     static String GET_MULTIPART_DATA = "getMultiPartData";

--- a/common/dataobjects/src/main/java/com/sastix/cms/common/content/ResourceFieldsQueryDTO.java
+++ b/common/dataobjects/src/main/java/com/sastix/cms/common/content/ResourceFieldsQueryDTO.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright(c) 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.sastix.cms.common.content;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * The specific object holds all the information related to Resource Query.
+ */
+@Getter @Setter @NoArgsConstructor @ToString
+public class ResourceFieldsQueryDTO {
+
+    /**
+     * The name of the resource queried.
+     */
+    private String queryResourceName;
+
+    /**
+     * The media-type of this resource.
+     */
+    private String queryResourceMediaType;
+
+    /**
+     * The author last updated this resource.
+     */
+    private String queryResourceAuthor;
+
+    /**
+     * The UID of this resource.
+     */
+    private String queryUID;
+
+    /**
+     * The page of the response.
+     */
+    private Integer page;
+
+    /**
+     * The size of the page.
+     */
+    private Integer size;
+
+    /**
+     * Constructor with the mandatory fields.
+     *
+     * @param queryUID a String with query UID
+     */
+    public ResourceFieldsQueryDTO(final String queryUID) {
+        this.queryUID = queryUID;
+    }
+
+}

--- a/common/dataobjects/src/main/java/com/sastix/cms/common/content/UpdateResourceDTO.java
+++ b/common/dataobjects/src/main/java/com/sastix/cms/common/content/UpdateResourceDTO.java
@@ -24,7 +24,6 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.constraints.NotNull;
-import java.util.Arrays;
 
 /**
  * The specific object all the information related to Update Resource.

--- a/integration-tests/src/test/java/com/sastix/cms/integration/AuthenticationTests.java
+++ b/integration-tests/src/test/java/com/sastix/cms/integration/AuthenticationTests.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @TestInstance(Lifecycle.PER_CLASS)
+@EnabledIfSystemProperty(named = "integration.tests.enabled", matches = "true")
 public class AuthenticationTests {
     
     CloseableHttpClient httpclient = HttpClients.createMinimal();

--- a/integration-tests/src/test/resources/application.properties
+++ b/integration-tests/src/test/resources/application.properties
@@ -1,3 +1,4 @@
+integration.tests.enabled=false
 cms.server.url=http://localhost:9082
 keycloak.auth-server-url=http://localhost:8080/auth
 keycloak.realm=CMS

--- a/server/src/main/java/com/sastix/cms/server/config/WebSecurityConfigWithKeycloak.java
+++ b/server/src/main/java/com/sastix/cms/server/config/WebSecurityConfigWithKeycloak.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
@@ -18,8 +19,8 @@ import org.springframework.security.web.authentication.session.RegisterSessionAu
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-@Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 @KeycloakConfiguration
 @ComponentScan(basePackageClasses = KeycloakSecurityComponents.class)
 @ConditionalOnProperty(value = "keycloak.enabled", matchIfMissing = false)

--- a/server/src/main/java/com/sastix/cms/server/domain/repositories/RevisionRepository.java
+++ b/server/src/main/java/com/sastix/cms/server/domain/repositories/RevisionRepository.java
@@ -34,6 +34,18 @@ public interface RevisionRepository extends CrudRepository<Revision, Long> {
 
     List<Revision> findByParentResourceUidOrderByIdDesc(@Param("uid") String uid);
 
+    @Query("SELECT r FROM Revision r ORDER BY r.id desc")
+    List<Revision> findRevisions();
+
+    @Query("SELECT r FROM Revision r ORDER BY r.id desc")
+    List<Revision> findRevisions(Pageable pageable);
+
     @Query("SELECT r FROM Revision r, Resource res WHERE r.resource.id = res.id AND res.uid = :uid ORDER BY r.id desc")
     List<Revision> findRevisions(@Param("uid") String uid, Pageable pageable);
+
+    @Query("SELECT r FROM Revision r, Resource res WHERE r.resource.id = res.id AND res.name = :name ORDER BY r.id desc")
+    List<Revision> findRevisionsByResourceName(@Param("name") String name, Pageable pageable);
+
+    @Query("SELECT r FROM Revision r, Resource res WHERE r.resource.id = res.id AND res.author = :author ORDER BY r.id desc")
+    List<Revision> findRevisionsByResourceAuthor(@Param("author") String author, Pageable pageable);
 }

--- a/server/src/main/java/com/sastix/cms/server/services/content/ResourceService.java
+++ b/server/src/main/java/com/sastix/cms/server/services/content/ResourceService.java
@@ -19,6 +19,7 @@ package com.sastix.cms.server.services.content;
 import com.sastix.cms.common.api.ContentApi;
 import com.sastix.cms.common.content.CreateResourceDTO;
 import com.sastix.cms.common.content.DataDTO;
+import com.sastix.cms.common.content.ResourceDTO;
 import com.sastix.cms.common.content.exceptions.ResourceAccessError;
 import com.sastix.cms.server.domain.entities.Resource;
 import com.sastix.cms.server.utils.MultipartFileSender;
@@ -27,6 +28,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 
 public interface ResourceService extends ContentApi {
 
@@ -40,5 +42,5 @@ public interface ResourceService extends ContentApi {
 
     Resource insertChildResource(final CreateResourceDTO createResourceDTO, final String parentUid, final Resource parentResource);
 
-
+    List<ResourceDTO> getResources();
 }

--- a/server/src/main/java/com/sastix/cms/server/services/content/impl/CommonResourceServiceImpl.java
+++ b/server/src/main/java/com/sastix/cms/server/services/content/impl/CommonResourceServiceImpl.java
@@ -17,6 +17,7 @@
 package com.sastix.cms.server.services.content.impl;
 
 import com.sastix.cms.common.content.ResourceDTO;
+import com.sastix.cms.common.content.ResourceFieldsQueryDTO;
 import com.sastix.cms.common.content.exceptions.ContentValidationException;
 import com.sastix.cms.common.content.exceptions.ResourceAccessError;
 import com.sastix.cms.server.dataobjects.DataMaps;
@@ -32,6 +33,7 @@ import org.apache.tika.Tika;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -68,9 +70,49 @@ public class CommonResourceServiceImpl {
         return resource;
     }
 
+    public List<Revision> getAllRevisions(){
+        return revisionRepository.findRevisions();
+    }
+
     public Revision getLatestRevision(String uid){
         final List<Revision> revisions = revisionRepository.findRevisions(uid, PageRequest.of(0, 1));
         return revisions.isEmpty()?null:revisions.get(0);
+    }
+
+    public Revision getLatestRevisionByResourceFields(ResourceFieldsQueryDTO resourceFieldsQueryDTO){
+        List<Revision> revisions = new ArrayList<>();
+        if (resourceFieldsQueryDTO.getQueryResourceName() != null){
+            revisions = revisionRepository.findRevisionsByResourceName(
+                resourceFieldsQueryDTO.getQueryResourceName(),
+                PageRequest.of(0, 1)
+            );
+        }
+        if (resourceFieldsQueryDTO.getQueryResourceAuthor() != null){
+            revisions = revisionRepository.findRevisionsByResourceAuthor(
+                resourceFieldsQueryDTO.getQueryResourceAuthor(),
+                PageRequest.of(0, 1)
+            );
+        }
+        return revisions.isEmpty() ? null : revisions.get(0);
+    }
+
+    public List<Revision> getRevisionsByResourceFields(ResourceFieldsQueryDTO resourceFieldsQueryDTO, Pageable pageable){
+        //TODO: expand for complex resource queries
+        List<Revision> revisions = new ArrayList<>();
+        if (resourceFieldsQueryDTO.getQueryResourceName() != null){
+            revisions = revisionRepository.findRevisionsByResourceName(
+                resourceFieldsQueryDTO.getQueryResourceName(),
+                pageable
+            );
+        }else if (resourceFieldsQueryDTO.getQueryResourceAuthor() != null){
+            revisions = revisionRepository.findRevisionsByResourceAuthor(
+                resourceFieldsQueryDTO.getQueryResourceAuthor(),
+                pageable
+            );
+        }else{
+            revisions = revisionRepository.findRevisions(pageable);
+        }
+        return revisions;
     }
 
     public ResourceDTO convertToDTO(Resource resource) {

--- a/server/src/main/java/com/sastix/cms/server/services/content/impl/singlenode/SingleResourceServiceImpl.java
+++ b/server/src/main/java/com/sastix/cms/server/services/content/impl/singlenode/SingleResourceServiceImpl.java
@@ -438,4 +438,40 @@ public class SingleResourceServiceImpl implements ResourceService {
         final byte[] responseData = Files.readAllBytes(responseFile);
         return responseData;
     }
+
+    @Override
+    public List<ResourceDTO> getResources() {
+        List<ResourceDTO> resources = new ArrayList<>();
+        List<Revision> revisions =  crs.getAllRevisions();
+        if(!revisions.isEmpty()){
+            for (Revision rev : revisions){
+                boolean isNotDeleted = rev.getDeletedAt() == null;
+                if(isNotDeleted){
+                    resources.add(crs.convertToDTO(rev.getResource()));
+                }
+            }
+        }
+        return resources;
+    }
+
+    @Override
+    public List<ResourceDTO> queryResourceByFields(ResourceFieldsQueryDTO resourceFieldsQueryDTO) throws ResourceAccessError, ResourceNotFound {
+        //find a non deleted resource
+        List<Revision> revisions = crs.getRevisionsByResourceFields(resourceFieldsQueryDTO, PageRequest.of(
+            resourceFieldsQueryDTO.getPage(),
+            resourceFieldsQueryDTO.getSize()
+        ));
+        List<ResourceDTO> result = new ArrayList<>();
+        if (revisions != null) {
+            for (Revision revision : revisions){
+                boolean isNotDeleted = revision.getDeletedAt() == null;
+                if (isNotDeleted) {
+                    result.add(crs.convertToDTO(revision.getResource()));
+                }
+            }
+        } else {
+            throw new ResourceAccessError("The supplied resource data are invalid and the resource cannot be retrieved.");
+        }
+        return result;
+    }
 }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -107,6 +107,6 @@ keycloak.auth-server-url=http://localhost:8080/auth
 keycloak.realm=CMS
 keycloak.resource=cms-server
 keycloak.credentials.secret=6bdcbcb3-457c-4d86-b5c3-5b9cda7198da
-keycloak.use-resource-role-mappings = true
+keycloak.use-resource-role-mappings=false
 keycloak.principal-attribute=preferred_username
 spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
The CMS server will now have the ability to search for resources with some basic fields. The content API will have the option to authorize requests per method. Specifically:

- The resources can be listed and paged.
- The resources can be searched via name or author fields.
- The access to Content API endpoints is managed per controller method using Sping Security expressions.
- The integration tests for authentication are now disabled if keycloak is disabled.
- The authentication principal uses realm roles per user.

This pull request resolves #11 , #12 .